### PR TITLE
Add messagepack array prefix so that multiple records will be processed.

### DIFF
--- a/spec/fluent/plugin/out_logtail_spec.rb
+++ b/spec/fluent/plugin/out_logtail_spec.rb
@@ -31,7 +31,7 @@ describe Fluent::LogtailOutput do
     it "should send a chunked request to the Logtail API" do
       stub = stub_request(:post, "https://in.logtail.com/").
         with(
-          :body => start_with("\x85\xA3age\x1A\xAArequest_id\xA242\xA9parent_id\xA6parent\xAArouting_id\xA7routing\xA2dt\xB4".force_encoding("ASCII-8BIT")),
+          :body => start_with("\xDD\x00\x00\x00\x01\x85\xA3age\x1A\xAArequest_id\xA242\xA9parent_id\xA6parent\xAArouting_id\xA7routing\xA2dt\xB4".force_encoding("ASCII-8BIT")),
           :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer abcd1234', 'Content-Type'=>'application/msgpack', 'User-Agent'=>'Logtail Fluentd/0.1.1'}
         ).
         to_return(:status => 202, :body => "", :headers => {})


### PR DESCRIPTION
See https://github.com/msgpack/msgpack/blob/master/spec.md#array-format-family.

Without the `0xdd<size>` prefix, the server only processes the first record in the chunk sent.

Also adds a couple of debug log lines to make diagnosing issues easier.

Resolves logtail/fluentd-plugin-logtail#3